### PR TITLE
Potential fix for code scanning alert no. 11: DOM text reinterpreted as HTML

### DIFF
--- a/site/search/main.js
+++ b/site/search/main.js
@@ -48,7 +48,7 @@ function displayResults (results) {
     if (!noResultsText) {
       noResultsText = "No results found";
     }
-    search_results.insertAdjacentHTML('beforeend', '<p>' + noResultsText + '</p>');
+    search_results.insertAdjacentHTML('beforeend', '<p>' + escapeHtml(noResultsText) + '</p>');
   }
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Programmers-Paradise/Annie-Docs/security/code-scanning/11](https://github.com/Programmers-Paradise/Annie-Docs/security/code-scanning/11)

To fix the issue, the value of `data-no-results-text` should be escaped before being inserted into the DOM. The `escapeHtml` function defined in the code (lines 24–29) is suitable for this purpose, as it replaces HTML meta-characters with their corresponding HTML entities. This ensures that any potentially malicious content in the `data-no-results-text` attribute is treated as plain text rather than executable HTML or JavaScript.

The fix involves modifying line 51 to use the `escapeHtml` function on `noResultsText` before concatenating it into the HTML string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
