### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,5 +1,8 @@
 name: Lighthouse CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]


### PR DESCRIPTION
Potential fix for [https://github.com/Programmers-Paradise/Annie-Docs/security/code-scanning/12](https://github.com/Programmers-Paradise/Annie-Docs/security/code-scanning/12)

To fix the issue, add a `permissions` block to the workflow to explicitly restrict the `GITHUB_TOKEN` to the least privileges required. Based on the workflow's functionality, the `contents: read` permission should suffice since the workflow only reads repository data and does not perform write operations.

The `permissions` block can be applied at the workflow level (global permissions) to cover all jobs that do not specify their own permissions. This change will be made at the root level of the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
