### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/link-and-size-check.yml
+++ b/.github/workflows/link-and-size-check.yml
@@ -1,4 +1,6 @@
 name: Documentation Link and Size Check
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Programmers-Paradise/Annie-Docs/security/code-scanning/13](https://github.com/Programmers-Paradise/Annie-Docs/security/code-scanning/13)

To fix the problem, add a `permissions` block to the workflow or the specific job to restrict the `GITHUB_TOKEN` to the minimum required privileges. In this case, the workflow only needs to read repository contents and upload artifacts. The minimal required permission is `contents: read`. Since artifact upload does not require additional permissions, setting `contents: read` at the workflow or job level is sufficient. The best practice is to add the `permissions` block at the top level of the workflow (just after the `name` and before `on`), so it applies to all jobs unless overridden.

**Steps:**
- Edit `.github/workflows/link-and-size-check.yml`.
- Insert the following block after the `name` field and before the `on` field:
  ```yaml
  permissions:
    contents: read
  ```
- No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
