### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sync-api-docs.yml
+++ b/.github/workflows/sync-api-docs.yml
@@ -1,5 +1,8 @@
 name: Sync API Docs
 
+permissions:
+  contents: write
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/Programmers-Paradise/Annie-Docs/security/code-scanning/14](https://github.com/Programmers-Paradise/Annie-Docs/security/code-scanning/14)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the actions used in the workflow:
- `contents: write` is required for committing and pushing changes to the repository.
- Other permissions can be set to `read` or omitted if not needed.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or specifically to the `sync-api-docs` job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
